### PR TITLE
Prometheus compatibility

### DIFF
--- a/configs/finetuning-prometheus.yaml
+++ b/configs/finetuning-prometheus.yaml
@@ -1,0 +1,56 @@
+data:
+  batch_size: 256
+  train_dir: '/groups/hep/jlt/prometheus_data/memmaped_pulses'
+  #val_dir: '/groups/hep/jlt/prometheus_data/memmaped_pulses'
+  train_events: 1000000
+  val_events: 10000  # Control validation set size
+  pin_memory: false
+  num_workers: 1
+  persistent_workers: true
+
+model:
+  embedding_dim: 256
+  dom_embed_dim: 128
+  mask_prob: 0.25
+  num_heads: 8
+  hidden_size: 1024  # 768 for swiglu
+  num_layers: 8
+  lambda_charge: 1.0
+  model_name: 'baseline_medium_small'
+
+training:
+  max_epochs: 4
+  val_check_interval: 1.0 # Validate once per epoch
+  accumulate_grad_batches: 8
+  # or use an absolute number of batches:
+  # val_check_interval: 1000  # Validate every 1000 batches
+  gpus: 1
+  precision: "16-mixed"
+  gradient_clip_val: 1
+  initial_lr: 1e-4
+  max_lr: 7e-4
+  weight_decay: 0.0
+  amsgrad: false
+  lr_scheduler: 'onecycle'
+  
+  # These will be calculated automatically
+  steps_per_epoch: null
+  total_steps: null
+  num_events: null
+  
+  pct_start: 0.01
+  final_div_factor: 0.133333
+  project: 'PolarBERT-finetuning'
+  
+  checkpoint:
+    dirpath: 'checkpoints'
+    save_top_k: 1
+    monitor: 'val/loss'
+    mode: 'min'
+    save_last: true
+    save_final: true
+
+pretrained:
+  model_type: 'flash'
+  checkpoint_path: 'checkpoints/Flash Transformer/final_model.pth'
+  freeze_backbone: false

--- a/configs/polarbert-prometheus-tuned-80ep.yaml
+++ b/configs/polarbert-prometheus-tuned-80ep.yaml
@@ -1,0 +1,54 @@
+data:
+  max_per_device_batch_size: 1024
+  train_dir: '/groups/hep/jlt/prometheus_data/memmaped_pulses'
+  #val_dir: '/groups/hep/jlt/prometheus_data/memmaped_pulses'
+  train_events: 358235
+  val_events: 40000  # Control validation set size
+  pin_memory: false
+  num_workers: 1
+  persistent_workers: true
+
+model:
+  embedding_dim: 256
+  dom_embed_dim: 128
+  num_heads: 8
+  hidden_size: 1024  # 768 for swiglu
+  num_layers: 8
+  lambda_charge: 1.0
+  model_name: 'tuned_medium_small'
+
+training:
+  mask_prob: 0.27
+  max_epochs: 80
+  logical_batch_size: 320
+  val_check_interval: 1.0  # Validate every epoch
+  # or use an absolute number of batches:
+  # val_check_interval: 1000  # Validate every 1000 batches
+  gpus: 1
+  precision: "16-mixed"
+  gradient_clip_val: 2.0
+  max_lr: 2.2e-3
+  adam_beta1: 0.92
+  adam_beta2: 0.9998
+  adam_eps: 3e-7
+  weight_decay: 0.014
+  amsgrad: false
+  lr_scheduler: 'onecycle'
+  
+  # These will be calculated automatically
+  steps_per_epoch: null
+  total_steps: null
+  num_events: null
+  
+  pct_start: 0.0045
+  div_factor: 25.0
+  final_div_factor: 1e4
+  project: 'PolarBERT-results'
+  
+  checkpoint:
+    dirpath: 'checkpoints/results/pretrained_medium_small-80ep'
+    save_top_k: 1
+    monitor: 'val/full_loss'
+    mode: 'min'
+    save_last: true
+    save_final: true

--- a/scripts/slurm.sh
+++ b/scripts/slurm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-#SBATCH --job-name=flash
-#SBATCH --output=../logs/flash_%j.log
+#SBATCH --job-name=polarbert
+#SBATCH --output=../../logs/polarbert_%j.log
 #SBATCH --partition=gr10_gpu
 #SBATCH --gres=gpu:1
 #SBATCH --ntasks=1
@@ -9,12 +9,15 @@
 #SBATCH --time=8:00:00
 
 
-source /groups/pheno/inar/mambaforge/etc/profile.d/conda.sh  # activate conda
-conda activate pytorch2  # activate your environment
+#source /groups/pheno/inar/mambaforge/etc/profile.d/conda.sh  # activate conda
+#conda activate pytorch2  # activate your environment
+
+source "$HOME"/.bashrc
+pyenv activate prometheus  # activate virtual environment
 
 # cd scripts
 
 # srun python base_training.py --config ../configs/mss_transformer_short.yaml --model_type flash
 # srun python base_training.py --config ../configs/mss_transformer_10ep.yaml --model_type flash
 
-srun python prometheus_training.py --config ../configs/mss_transformer_prometheus.yaml --model_type flash 
+srun python pretraining.py --config ../../configs/polarbert-prometheus.yaml --model_type flash 

--- a/src/polarbert/base_model.py
+++ b/src/polarbert/base_model.py
@@ -67,8 +67,11 @@ class SimpleTransformer(pl.LightningModule):
         optimizer = torch.optim.AdamW(
             self.parameters(),
             lr=float(self.config['training']['initial_lr']),
-            betas=(0.9, 0.999),
-            eps=1e-08,
+            betas=(
+                float(self.config['training'].get('adam_beta1', 0.9)),
+                float(self.config['training'].get('adam_beta2', 0.999))
+            ),
+            eps=float(self.config['training'].get('adam_eps', 1e-8)),
             weight_decay=float(self.config['training']['weight_decay']),
             amsgrad=bool(self.config['training'].get('amsgrad', False))
         )
@@ -83,6 +86,7 @@ class SimpleTransformer(pl.LightningModule):
                 max_lr=float(self.config['training']['max_lr']),
                 total_steps=total_steps,
                 pct_start=float(self.config['training']['pct_start']),
+                div_factor=float(self.config['training']['div_factor']),
                 final_div_factor=float(self.config['training']['final_div_factor']),
                 anneal_strategy='cos'
             )

--- a/src/polarbert/base_model.py
+++ b/src/polarbert/base_model.py
@@ -64,33 +64,44 @@ class SimpleTransformer(pl.LightningModule):
         return loss
     
     def configure_optimizers(self):
-        optimizer = torch.optim.AdamW(
-            self.parameters(),
-            lr=float(self.config['training']['initial_lr']),
-            betas=(
-                float(self.config['training'].get('adam_beta1', 0.9)),
-                float(self.config['training'].get('adam_beta2', 0.999))
-            ),
-            eps=float(self.config['training'].get('adam_eps', 1e-8)),
-            weight_decay=float(self.config['training']['weight_decay']),
-            amsgrad=bool(self.config['training'].get('amsgrad', False))
+        return _configure_optimizers(self.config, self.parameters())
+
+
+def _configure_optimizers(config, parameters):
+
+    if config['training']['lr_scheduler'] == 'constant':
+        initial_lr = float(config['training']['initial_lr'])
+    elif config['training']['lr_scheduler'] == 'onecycle':
+        initial_lr = float(config['training']['max_lr']) / float(config['training']['div_factor'])
+    else:
+        raise ValueError(f"Unknown scheduler: {config['training']['lr_scheduler']}")
+    
+    optimizer = torch.optim.AdamW(
+        parameters,
+        lr=initial_lr,
+        betas=(
+            float(config['training'].get('adam_beta1', 0.9)),
+            float(config['training'].get('adam_beta2', 0.999))
+        ),
+        eps=float(config['training'].get('adam_eps', 1e-8)),
+        weight_decay=float(config['training']['weight_decay']),
+        amsgrad=bool(config['training'].get('amsgrad', False))
+    )
+
+    if config['training']['lr_scheduler'] == 'constant':
+        return optimizer
+    elif config['training']['lr_scheduler'] == 'onecycle':
+        # Use the pre-calculated total_steps from config
+        total_steps = config['training']['total_steps']
+        scheduler = OneCycleLR(
+            optimizer,
+            max_lr=float(config['training']['max_lr']),
+            total_steps=total_steps,
+            pct_start=float(config['training']['pct_start']),
+            div_factor=float(config['training']['div_factor']),
+            final_div_factor=float(config['training']['final_div_factor']),
+            anneal_strategy='cos'
         )
-
-        if self.config['training']['lr_scheduler'] == 'constant':
-            return optimizer
-        elif self.config['training']['lr_scheduler'] == 'onecycle':
-            # Use the pre-calculated total_steps from config
-            total_steps = self.config['training']['total_steps']
-            scheduler = OneCycleLR(
-                optimizer,
-                max_lr=float(self.config['training']['max_lr']),
-                total_steps=total_steps,
-                pct_start=float(self.config['training']['pct_start']),
-                div_factor=float(self.config['training']['div_factor']),
-                final_div_factor=float(self.config['training']['final_div_factor']),
-                anneal_strategy='cos'
-            )
-            return [optimizer], [{"scheduler": scheduler, "interval": "step", "frequency": 1}]
-        else:
-            raise ValueError(f"Unknown scheduler: {self.config['training']['lr_scheduler']}")
-
+        return [optimizer], [{"scheduler": scheduler, "interval": "step", "frequency": 1}]
+    else:
+        assert False

--- a/src/polarbert/embedding.py
+++ b/src/polarbert/embedding.py
@@ -6,7 +6,7 @@ class IceCubeEmbedding(nn.Module):
         super().__init__()
         embedding_dim = config['model']['embedding_dim']
         dom_embed_dim = config['model']['dom_embed_dim']
-        self.mask_prob = config['model']['mask_prob']
+        self.mask_prob = config['training']['mask_prob']
         num_doms = 5160
         self.dom_embedding = nn.Embedding(num_doms + 2, dom_embed_dim)
         self.features_embedding = nn.Linear(3, embedding_dim - dom_embed_dim)

--- a/src/polarbert/finetuning.py
+++ b/src/polarbert/finetuning.py
@@ -144,11 +144,16 @@ def main():
     parser.add_argument('--name', type=str, default=None)
     parser.add_argument("--job_id", type=str, default=None)
     parser.add_argument("--model_type", type=str, choices=list(MODEL_CLASSES.keys()), default='base')
+    parser.add_argument("--checkpoint_path", type=str, default=None, help="Optional path for pretrained model checkpoint")
     args = parser.parse_args()
 
     # Load and process config
     config = load_and_process_config(args.config)
     
+    # Override checkpoint_path if provided in command line
+    if args.checkpoint_path is not None:
+        config.setdefault('pretrained', {})['checkpoint_path'] = args.checkpoint_path
+
     # Add model type to config if not present
     if 'model_type' not in config.get('pretrained', {}):
         config.setdefault('pretrained', {})['model_type'] = args.model_type
@@ -177,7 +182,7 @@ def main():
     
     # Setup training
     wandb_logger = WandbLogger(
-        project=config['training'].get('project', '2024-09-IceCube-finetuning'),
+        project=config['training'].get('project', 'PolarBERT-finetuning'),
         name=model_name,
         config=config
     )

--- a/src/polarbert/pretraining.py
+++ b/src/polarbert/pretraining.py
@@ -9,7 +9,7 @@ import yaml
 import argparse
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Tuple, Any
 import math
 
 from polarbert.prometheus_dataset import IceCubeDataset
@@ -86,12 +86,12 @@ def setup_callbacks(config: Dict[str, Any], model_name: str) -> list:
     
     return callbacks
 
-def get_dataloaders(config: Dict[str, Any]):
+def default_target_transform(y, c):
+    return None, c.astype(np.float32)
+
+def get_dataloaders(config: Dict[str, Any], target_transform=default_target_transform) -> Tuple[DataLoader, DataLoader]:
     def transform(x, l):
         return x.astype(np.float32), l.astype(np.float32)
-    def target_transform(y, c):
-        y = np.vstack([y['initial_state_azimuth'].astype(np.float32), y['initial_state_zenith'].astype(np.float32)]).T
-        return y, c.astype(np.float32)
     
     # Training dataset
     full_dataset = IceCubeDataset(

--- a/src/polarbert/prometheus_dataset.py
+++ b/src/polarbert/prometheus_dataset.py
@@ -93,8 +93,10 @@ class IceCubeDataset(IterableDataset):
         return generator()
     
     def slice(self, start, end):
-        if end is None:
+        if end is None or end > self.x.shape[0]:
             end = self.x.shape[0]
+        assert(end > start)
+        assert(start >= 0)
         slc = copy.copy(self) # Shallow copy
         slc.start = start
         slc.end = end

--- a/src/polarbert/prometheus_dataset.py
+++ b/src/polarbert/prometheus_dataset.py
@@ -1,0 +1,133 @@
+import numpy as np
+import torch
+from torch.utils.data import IterableDataset
+import json
+import copy
+import os
+
+class IceCubeDataset(IterableDataset):
+    """
+    dataset = IceCubeDataset(
+        '/groups/pheno/inar/icecube_kaggle/memmaped_1M_127', 
+        batch_size=2048,
+        transform=lambda x: x.astype(np.float32), 
+        target_transform=lambda x: x.astype(np.float32)
+    )
+    """
+    def __init__(self, data_dir: str, batch_size: int, start=0, end=None, transform=None, target_transform=None):
+        self.batch_size = batch_size
+        self.transform = transform
+        self.target_transform = target_transform
+        
+        for filename in ['x.npy', 'l.npy', 'c.npy', 'memmap_properties.json']:
+            if not os.path.isfile(os.path.join(data_dir, filename)):
+                raise FileNotFoundError(f'{filename} not found in {data_dir}')
+        
+        self.has_labels = os.path.isfile(os.path.join(data_dir, 'y.npy'))
+        
+        with open(os.path.join(data_dir, 'memmap_properties.json'), 'r') as f:
+            memmap_props = json.load(f)
+        
+        self.x = np.memmap(
+            os.path.join(data_dir, 'x.npy'), mode='r',
+            shape=tuple(memmap_props['x']['shape']),
+            dtype=memmap_props['x']['dtype'],
+        )
+        self.l = np.memmap(
+            os.path.join(data_dir, 'l.npy'), mode='r',
+            shape=tuple(memmap_props['l']['shape']),
+            dtype=memmap_props['l']['dtype'],
+        )
+        self.c = np.memmap(
+            os.path.join(data_dir, 'c.npy'), mode='r',
+            shape=tuple(memmap_props['c']['shape']),
+            dtype=memmap_props['c']['dtype'],
+        )
+        
+        if self.has_labels:
+            self.y = np.memmap(
+                os.path.join(data_dir, 'y.npy'), mode='r',
+                shape=tuple(memmap_props['y']['shape']),
+                dtype=[tuple(dt) for dt in memmap_props['y']['dtype']],
+            )
+            self.labels = [field_name for field_name, _ in memmap_props['y']['dtype']]
+        else:
+            self.y = None
+            self.labels = None
+            
+        if end is None:
+            end = self.x.shape[0]
+        assert(end > start)
+        self.start = start
+        self.end = end
+        self.SEQ_LENGTH = self.x.shape[1]
+        self.N_FEATURES = self.x.shape[2]
+
+    def __len__(self):
+        return (self.end - self.start) // self.batch_size - 1
+
+    def __iter__(self):
+        def generator():
+            Nevents = self.x.shape[0]
+            rand_int = np.random.randint(0, self.batch_size)
+            batch_start_indices = np.arange(Nevents)[
+                self.start + rand_int : self.end - self.batch_size + 1 : self.batch_size]
+            np.random.shuffle(batch_start_indices)
+            for idx in batch_start_indices:
+                assert(idx >= self.start)
+                assert(idx + self.batch_size <= self.end)
+                x = self.x[idx:idx+self.batch_size,:,:]
+                l = self.l[idx:idx+self.batch_size]
+                
+                if self.transform:
+                    x, l = self.transform(x, l)
+                
+                if self.has_labels:
+                    y = self.y[idx:idx+self.batch_size]  # remove second dimension
+                    c = self.c[idx:idx+self.batch_size]
+                    if self.target_transform:
+                        y, c = self.target_transform(y, c)
+                    yield (x, l), (y, c)
+                else:
+                    yield (x, l), None
+        return generator()
+    
+    def slice(self, start, end):
+        if end is None:
+            end = self.x.shape[0]
+        slc = copy.copy(self) # Shallow copy
+        slc.start = start
+        slc.end = end
+        return slc
+
+
+from torch.utils.data import DataLoader
+
+def train_validation_loaders(dataset, train_ratio=0.8, pin_memory=False, persistent_workers=True):
+    """
+    usage example:
+
+    train_dataloader, val_dataloader = train_validation_loaders(
+    dataset,
+    train_ratio = TRAIN_RATIO,
+    pin_memory=True,
+    )
+    """
+
+    #val_size = len(dataset) - train_size
+    total_batches = len(dataset)
+    train_batches = int(train_ratio * total_batches)
+    val_batches = total_batches - train_batches
+    train_size = train_batches * dataset.batch_size
+    val_size = val_batches * dataset.batch_size
+    #train_dataset, val_dataset = torch.utils.data.random_split(dataset, [train_size, val_size])
+    train_dataset = dataset.slice(0, train_size)
+    val_dataset = dataset.slice(train_size, train_size+val_size)
+    # Note: the split is not random anymore
+    train_dataloader = DataLoader(
+        train_dataset, batch_size=None, num_workers=1,
+        pin_memory=pin_memory, persistent_workers=persistent_workers)
+    val_dataloader = DataLoader(
+        val_dataset, batch_size=None, num_workers=1,
+        pin_memory=pin_memory, persistent_workers=persistent_workers)
+    return train_dataloader, val_dataloader


### PR DESCRIPTION
This PR makes PolarBERT compatible with the new Prometheus dataset. Specifically:
- It adds a modified version of `IceCubeDataset` that works with the Prometheus data.
- It adds a new `EnergyRegressionHead` and lets the user specify the fine-tuning task in `finetuning.py`.
- It makes both pretraining and fine-tuning compatible with W&B sweeps.
- It includes a set of optimised training hyperparameters for pretraining.

What remains to be done:
- Merge the `IceCubeDataset`s for Kaggle and Prometheus.
- Implement a classification head for neutrino flavour tagging.
- Make the code more modular, especially around fine-tuning heads (lots of code could be shared here).